### PR TITLE
Benchmarks with benchfella

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Snapshots saved by benchfella
+/bench/snapshots
+/bench/graphs

--- a/bench/series_bench.exs
+++ b/bench/series_bench.exs
@@ -1,0 +1,9 @@
+defmodule SeriesBench do
+  use Benchfella
+
+  @length 100_000
+
+  bench "Fibonacci.series(#{@length})" do
+    Fibonacci.series(@length)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Fibonacci.Mixfile do
       licenses: ["MIT"],
       links: %{
         "GitHub" => "https://github.com/stevegrossi/fibonacci",
-        "Docs" => "http://hexdocs.pm/fibonacci/"}
+        "Docs" => "https://hexdocs.pm/fibonacci/"}
     ]
   end
 
@@ -50,7 +50,8 @@ defmodule Fibonacci.Mixfile do
   defp deps do
     [
       {:ex_doc, "~> 0.13", only: :dev},
-      {:earmark, "~> 1.0.1", only: :dev}
+      {:earmark, "~> 1.0.1", only: :dev},
+      {:benchfella, "~> 0.3.0", only: :dev}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+%{"benchfella": {:hex, :benchfella, "0.3.3", "bbde48b5fe1ef556baa7ad933008e214e050e81ddb0916350715f5759fb35c0c", [:mix], []},
+  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}


### PR DESCRIPTION
Especially useful is the `mix bench.cmp` task, which will compare the last 2 benchmarks. Run a benchmark on master and then on a branch with changes in order to compare the performance:

``` shell
$ mix bench.cmp
bench/snapshots/2016-09-11_10-00-12.snapshot vs
bench/snapshots/2016-09-11_10-00-28.snapshot

## SeriesBench
Fibonacci.series(100000)    1.01
```

This shows that the second benchmark was 1.01x the speed of the previous one, though the output could make this clearer.
